### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ipython==2.4.1
-jsonpickle==1.4.1
+ipython==8.4.0
+jsonpickle==2.2.0


### PR DESCRIPTION
The version of ipython that was internally using a function from (`encodestring`) from `base64` module. This function was deprecated in some earlier python version and has been removed in python 3.9. Hence, this PR is to update the versions of the libraries to the current latest versions.

![image](https://user-images.githubusercontent.com/546476/178090178-88a128e8-201e-47e0-9d84-4e56d85b8c06.png)
