### PR TITLE
add caching for already checked dependencies

### DIFF
--- a/extract_bc_sources.py
+++ b/extract_bc_sources.py
@@ -67,12 +67,12 @@ for pkgs in packages_available:
     reverse_dependencies = []
     dependency_list = p.dependency_map[pkgs]
     for dependencies in dependency_list:
-        if dependencies in checked_dep_cache:
-            continue
+        if dependencies not in checked_dep_cache:
+            subprocess.call(["sudo apt -yq install", str(dependencies)], shell=True)
+            checked_dep_cache.add(dependencies)
         # install all reverse dependencies might be too slow (not necessary), uncomment if needed
-        #for reverse_deps in p.reverse_dependency_map[dependencies]:
-        #    subprocess.call(['sudo apt -yq install', str(reverse_deps)], shell=True)        
-        subprocess.call(['sudo apt -yq install', str(dependencies)], shell=True)
+        # for reverse_deps in p.reverse_dependency_map[dependencies]:
+        #    subprocess.call(['sudo apt -yq install', str(reverse_deps)], shell=True)
         reverse_dependencies.extend(p.reverse_dependency_map[dependencies])
     
     for lib in reverse_dependencies:

--- a/extract_bc_sources.py
+++ b/extract_bc_sources.py
@@ -59,11 +59,16 @@ packages_available = p.all_pkg_entries
 cmd = "(" + "export DEBIAN_FRONTEND=noninteractive" + ")"
 subprocess.call(cmd, shell=True)
 
+# already checked dependencies
+checked_dep_cache = set()
+
 for pkgs in packages_available:
     
     reverse_dependencies = []
     dependency_list = p.dependency_map[pkgs]
     for dependencies in dependency_list:
+        if dependencies in checked_dep_cache:
+            continue
         # install all reverse dependencies might be too slow (not necessary), uncomment if needed
         #for reverse_deps in p.reverse_dependency_map[dependencies]:
         #    subprocess.call(['sudo apt -yq install', str(reverse_deps)], shell=True)        


### PR DESCRIPTION
@Machiry -- This PR adds a simple cache for already checked dependencies. This helps speed up the dependency checking by a lot, when a lot of packages are to be downloaded.